### PR TITLE
Accept nulls

### DIFF
--- a/database/migrations/2019_04_03_161926_create_purchases_table.php
+++ b/database/migrations/2019_04_03_161926_create_purchases_table.php
@@ -19,8 +19,8 @@ class CreatePurchasesTable extends Migration
             $table->timestamps();
         });
         Schema::table('purchases', function (Blueprint $table) {
-            $table->biginteger('user_id')->unsigned();
-            $table->biginteger('product_id')->unsigned();
+            $table->biginteger('user_id')->unsigned()->nullable();;
+            $table->biginteger('product_id')->unsigned()->nullable();;
             $table->foreign('user_id')
                   ->references('id')
                   ->on('users')


### PR DESCRIPTION
Set user_id & product_id in  purchases table to accept nulls
to avoid this error

when run php artisan migrate

 Illuminate\Database\QueryException  : SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL (SQL: alter table "purchases" add column "product_id" integer not null)

 ecommerce/vendor/laravel/framework/src/Illuminate/Database/Connection.php:664
    660|         // If an exception occurs when attempting to run a query, we'll format the error
    661|         // message to include the bindings with SQL, which will make this exception a
    662|         // lot more helpful to the developer instead of just the database's errors.
    663|         catch (Exception $e) {
  > 664|             throw new QueryException(
    665|                 $query, $this->prepareBindings($bindings), $e
    666|             );
    667|         }
    668| 

  Exception trace:

  1   PDOException::("SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL")
      ecommerce/vendor/laravel/framework/src/Illuminate/Database/Connection.php:452

  2   PDO::prepare("alter table "purchases" add column "product_id" integer not null")
     ecommerce/vendor/laravel/framework/src/Illuminate/Database/Connection.php:452